### PR TITLE
Add 'Pin to Favorites' context menu option for tabs

### DIFF
--- a/Nook/Components/Sidebar/SpaceSection/SpaceTab.swift
+++ b/Nook/Components/Sidebar/SpaceSection/SpaceTab.swift
@@ -151,6 +151,14 @@ struct SpaceTab: View {
             Button { browserManager.splitManager.enterSplit(with: tab, placeOn: .left, in: windowState) }
             label: { Label("Open in Split (Left)", systemImage: "rectangle.split.2x1") }
             Divider()
+            if !tab.isPinned && !tab.isSpacePinned {
+                Button(action: {
+                    browserManager.tabManager.pinTab(tab)
+                }) {
+                    Label("Pin to Favorites", systemImage: "pin")
+                }
+                Divider()
+            }
             if tab.hasAudioContent || tab.isAudioMuted {
                 Button(action: onMute) {
                     Label(tab.isAudioMuted ? "Unmute Audio" : "Mute Audio",

--- a/Nook/Managers/TabManager/TabManager.swift
+++ b/Nook/Managers/TabManager/TabManager.swift
@@ -1643,6 +1643,7 @@ class TabManager: ObservableObject {
             print("No space to place unpinned tab")
             return
         }
+        moved.isPinned = false
         moved.spaceId = sid
         var arr = tabsBySpace[sid] ?? []
         arr.insert(moved, at: 0)


### PR DESCRIPTION
This feature adds a convenient context menu option to pin tabs directly to the favorites section without requiring manual drag-and-drop.

Changes:
- Added "Pin to Favorites" option to tab context menus in SpaceTab view
- Fixed bug where unpinTab() wasn't clearing the isPinned flag, which prevented the context menu option from reappearing after unpinning