### PR TITLE
feature: New Tab on double-tap gesture in Sidebar

### DIFF
--- a/Nook/Components/Sidebar/SidebarView.swift
+++ b/Nook/Components/Sidebar/SidebarView.swift
@@ -176,6 +176,10 @@ struct SidebarView: View {
                     .conditionalWindowDrag()
                     .frame(minHeight: 40)
                     .zIndex(0)
+                    .onTapGesture(count: 2) {
+                        // Double-tap to open command palette for new tab
+                        browserManager.openCommandPalette()
+                    }
             }
 
 
@@ -257,6 +261,10 @@ struct SidebarView: View {
         .animation(
             shouldAnimate ? .easeInOut(duration: 0.18) : nil,
             value: essentialsCount)
+        .onTapGesture(count: 2) {
+            // Double-tap on empty space to open command palette for new tab
+            browserManager.openCommandPalette()
+        }
         
         let finalContent = ZStack {
                 if !windowState.isSidebarMenuVisible {
@@ -308,6 +316,10 @@ struct SidebarView: View {
         }
         .frame(width: effectiveWidth)
         .padding()
+        .onTapGesture(count: 2) {
+            // Double-tap on empty state to open command palette for new tab
+            browserManager.openCommandPalette()
+        }
     }
 
     private var spacesPageView: some View {

--- a/Nook/NookApp.swift
+++ b/Nook/NookApp.swift
@@ -475,6 +475,22 @@ struct BackgroundWindowModifier: NSViewRepresentable {
         let view = NSView()
         DispatchQueue.main.async {
             if let window = view.window {
+                // Only configure the window if it hasn't been configured already
+                // Check if the window is already in the desired state to avoid conflicts
+                let desiredStyleMask: NSWindow.StyleMask = [
+                    .titled, .closable, .miniaturizable, .resizable,
+                    .fullSizeContentView,
+                ]
+                
+                // Only set style mask if it's different from current state
+                if window.styleMask != desiredStyleMask {
+                    // Check if window is in fullscreen mode to avoid the error
+                    let isInFullScreen = window.styleMask.contains(.fullScreen)
+                    if !isInFullScreen {
+                        window.styleMask = desiredStyleMask
+                    }
+                }
+                
                 window.toolbar?.isVisible = false
                 window.titlebarAppearsTransparent = true
                 window.backgroundColor = .clear
@@ -482,10 +498,6 @@ struct BackgroundWindowModifier: NSViewRepresentable {
                 window.isReleasedWhenClosed = false
                 // window.isMovableByWindowBackground = true // Disabled - use SwiftUI-based window drag system instead
                 window.isMovable = true
-                window.styleMask = [
-                    .titled, .closable, .miniaturizable, .resizable,
-                    .fullSizeContentView,
-                ]
 
                 window.standardWindowButton(.closeButton)?.isHidden = true
                 window.standardWindowButton(.zoomButton)?.isHidden = true


### PR DESCRIPTION
Implements a double-tap gesture on the sidebar to open the command palette, allowing users to quickly create a new tab.

This feature is implemented on the title bar, empty space, and empty state sections of the sidebar.