### PR TITLE
Reynold29 - feature: New Tab on double-tap gesture in Sidebar

### DIFF
--- a/Nook/Components/Sidebar/SidebarView.swift
+++ b/Nook/Components/Sidebar/SidebarView.swift
@@ -178,6 +178,10 @@ struct SidebarView: View {
                     .conditionalWindowDrag()
                     .frame(minHeight: 40)
                     .zIndex(0)
+                    .onTapGesture(count: 2) {
+                        // Double-tap to open command palette for new tab
+                        browserManager.openCommandPalette()
+                    }
             }
 
 
@@ -273,6 +277,10 @@ struct SidebarView: View {
         .animation(
             shouldAnimate ? .easeInOut(duration: 0.18) : nil,
             value: essentialsCount)
+        .onTapGesture(count: 2) {
+            // Double-tap to open command palette for new tab
+            browserManager.openCommandPalette()
+        }
         
         let finalContent = ZStack {
                 if windowState.isSidebarAIChatVisible {
@@ -330,6 +338,10 @@ struct SidebarView: View {
         }
         .frame(width: effectiveWidth)
         .padding()
+        .onTapGesture(count: 2) {
+            // Double-tap to open command palette for new tab
+            browserManager.openCommandPalette()
+        }
     }
 
     private var spacesPageView: some View {

--- a/Nook/NookApp.swift
+++ b/Nook/NookApp.swift
@@ -507,6 +507,22 @@ struct BackgroundWindowModifier: NSViewRepresentable {
         let view = NSView()
         DispatchQueue.main.async {
             if let window = view.window {
+                // Only configure the window if it hasn't been configured already
+                // Check if the window is already in the desired state to avoid conflicts
+                let desiredStyleMask: NSWindow.StyleMask = [
+                    .titled, .closable, .miniaturizable, .resizable,
+                    .fullSizeContentView,
+                ]
+                
+                // Only set style mask if it's different from current state
+                if window.styleMask != desiredStyleMask {
+                    // Check if window is in fullscreen mode to avoid the error
+                    let isInFullScreen = window.styleMask.contains(.fullScreen)
+                    if !isInFullScreen {
+                        window.styleMask = desiredStyleMask
+                    }
+                }
+                
                 window.toolbar?.isVisible = false
                 window.titlebarAppearsTransparent = true
                 window.backgroundColor = .clear


### PR DESCRIPTION
feature: New Tab on double-tap gesture in Sidebar
Implements a double-tap gesture on the sidebar to open the command palette, allowing users to quickly create a new tab.

This feature is implemented on the title bar, empty space, and empty state sections of the sidebar.