### PR TITLE
bugfix/qol: sidebar clear-btn text clipping & animation addition

### DIFF
--- a/Nook/Components/Sidebar/SpaceSection/SpaceSeparator.swift
+++ b/Nook/Components/Sidebar/SpaceSection/SpaceSeparator.swift
@@ -13,11 +13,18 @@ struct SpaceSeparator: View {
     @EnvironmentObject var browserManager: BrowserManager
 
     var body: some View {
-        HStack {
+        let hasTabs = !browserManager.tabManager.tabs(in: browserManager.tabManager.currentSpace!).isEmpty
+        let showClearButton = isHovering && hasTabs
+        
+        HStack(spacing: 0) {
             RoundedRectangle(cornerRadius: 100)
                 .fill(Color.white.opacity(0.1))
                 .frame(height: 2)
-            if(isHovering && !browserManager.tabManager.tabs(in: browserManager.tabManager.currentSpace!).isEmpty) {
+                .frame(maxWidth: showClearButton ? .infinity : .infinity)
+                .padding(.trailing, showClearButton ? 8 : 0)
+                .animation(.easeInOut(duration: 0.15), value: showClearButton)
+            
+            if hasTabs {
                 Button(action: onClear) {
                     Text("↓ Clear")
                         .font(.system(size: 12, weight: .medium))
@@ -26,9 +33,14 @@ struct SpaceSeparator: View {
                 }
                 .buttonStyle(PlainButtonStyle())
                 .help("Clear all regular tabs")
+                .opacity(showClearButton ? 1 : 0)
+                .offset(x: showClearButton ? 0 : 20)
+                .frame(width: showClearButton ? nil : 0)
+                .animation(.easeInOut(duration: 0.15), value: showClearButton)
                 .onHover { state in
-                    isClearHovered = state
-                    
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isClearHovered = state
+                    }
                 }
             }
         }

--- a/Nook/Components/Sidebar/SpaceSection/SpaceView.swift
+++ b/Nook/Components/Sidebar/SpaceSection/SpaceView.swift
@@ -152,7 +152,9 @@ struct SpaceView: View {
             folderChangeCount += 1
         }
         .onHover { state in
-            isHovered = state
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovered = state
+            }
         }
       }
     
@@ -501,6 +503,7 @@ struct SpaceView: View {
                 browserManager.tabManager.clearRegularTabs(for: space.id)
             }
             .padding(.horizontal, 8)
+            .padding(.top, 4)
 
             newTabButtonSection
         }
@@ -541,7 +544,7 @@ struct SpaceView: View {
         }
         .frame(minWidth: 0, maxWidth: innerWidth, alignment: .leading)
         .contentShape(Rectangle())
-        .padding(.top, 8)
+        .padding(.top, 2)
         .onDrop(
             of: [.text],
             delegate: SidebarSectionDropDelegateSimple(
@@ -659,7 +662,7 @@ struct SpaceView: View {
                         .animation(.easeInOut(duration: 0.15), value: isActive)
                 }
         }
-        .padding(.top, 8)
+        .padding(.top, 2)
         .contentShape(Rectangle())
         .onDrop(
             of: [.text],


### PR DESCRIPTION
First time doing an open source contribution!

Bugfix: Adjust the position of the separator/clear-btn in sidebar so 'clear' does not get clipped.

Before:
<img width="200" height="254" alt="Screenshot 2025-11-11 at 8 51 32 PM" src="https://github.com/user-attachments/assets/bf843adc-00dd-4c37-8fdb-ab87b8047e6f" />
After:
<img width="200" height="254" alt="Screenshot 2025-11-11 at 8 55 18 PM" src="https://github.com/user-attachments/assets/46fe38f5-5b2c-47f8-aa82-00d639784745" />

QOL Visual Update: separator/clear-btn animation

https://github.com/user-attachments/assets/fd4549d0-67db-476d-9c3f-ba54c7f638ac

