### PR TITLE
fix: use ditto for notarization archive and add runtime flag to Sparkle

### DIFF
--- a/.github/workflows/macos-notarize.yml
+++ b/.github/workflows/macos-notarize.yml
@@ -112,7 +112,7 @@ jobs:
           # Sign the framework version (Versions/B) — do NOT also sign the
           # top-level Sparkle.framework symlink; it resolves to the same Versions/B
           # directory and double-signing would invalidate the signature.
-          codesign --force --sign "$SIGNING_IDENTITY" --timestamp "$SPARKLE"
+          codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime "$SPARKLE"
 
           # Re-sign the main app with entitlements and hardened runtime
           codesign --force --sign "$SIGNING_IDENTITY" --timestamp \
@@ -134,7 +134,10 @@ jobs:
             --team-id "$APPLE_TEAM_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD"
 
-          zip -r Nook.zip "Nook.app"
+          # ditto preserves macOS symlinks and extended attributes; zip -r does not.
+          # Broken symlinks in the archive cause "invalid signature" errors because
+          # the bundle seal references symlink targets, not file copies.
+          ditto -c -k --keepParent "Nook.app" Nook.zip
           SUBMIT_OUTPUT=$(xcrun notarytool submit "Nook.zip" \
             --keychain-profile "nook-notary" \
             --wait 2>&1)


### PR DESCRIPTION
zip -r dereferences symlinks (e.g. Sparkle.framework/Sparkle becomes a regular file copy) which breaks the bundle code seal — Apple's verifier checks that sealed symlinks are still symlinks, so it flags MacOS/Nook (where the bundle signature lives) and Sparkle.framework/Sparkle as having invalid signatures.

ditto -c -k --keepParent preserves symlinks, extended attributes, and all macOS filesystem metadata required for valid notarization archives.

Also add --options runtime to the Sparkle.framework/Versions/B signing step so the framework dylib passes Apple's hardened runtime check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS application signing process to comply with Apple's hardened runtime security requirements, ensuring successful notarization and reliable installation on all macOS versions.
  * Improved application packaging method to properly preserve critical system file attributes during notarization, preventing signature validation issues that could prevent app installation and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->