### PR TITLE
Quit Fixes: correct quitting behaviour when 'warn' is false, improved keyboard input, closer visual design

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -149,17 +149,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     ///
     /// - Returns: Always returns `.terminateLater` to handle termination asynchronously
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        let reason = NSAppleEventManager.shared()
-            .currentAppleEvent?
-            .attributeDescriptor(forKeyword: kAEQuitReason)
-
-        switch reason?.enumCodeValue {
-        case nil:
-            handleTermination(sender: sender, shouldTerminate: true)
-        default:
-            handleTermination(sender: sender, shouldTerminate: true)
+        // When "warn before quitting" is disabled, terminate(nil) is called directly
+        // from the SwiftUI CommandGroup button action. Returning .terminateLater in that
+        // context deadlocks because the async Task can't execute during the termination
+        // run loop mode. Since the user opted out of the warning, just quit immediately.
+        let askBeforeQuit = userDefaults.bool(forKey: "settings.askBeforeQuit")
+        if !askBeforeQuit {
+            return .terminateNow
         }
 
+        handleTermination(sender: sender, shouldTerminate: true)
         return .terminateLater
     }
 

--- a/App/NookCommands.swift
+++ b/App/NookCommands.swift
@@ -80,6 +80,15 @@ struct NookCommands: Commands {
         CommandGroup(replacing: .newItem) {}
         CommandGroup(replacing: .windowList) {}
 
+        // Replace the standard Quit menu item to route through showQuitDialog(),
+        // which respects the "warn before quitting" setting
+        CommandGroup(replacing: .appTermination) {
+            Button("Quit Nook") {
+                browserManager.showQuitDialog()
+            }
+            .keyboardShortcut("q", modifiers: .command)
+        }
+
         // App Menu Section (under Nook)
         CommandGroup(after: .appInfo) {
             Divider()
@@ -217,13 +226,6 @@ struct NookCommands: Commands {
             }
             .modifier(dynamicShortcut(.openDevTools))
             .disabled(browserManager.currentTabForActiveWindow() == nil)
-
-            Divider()
-
-            Button("Force Quit App") {
-                browserManager.showQuitDialog()
-            }
-            .modifier(dynamicShortcut(.closeBrowser))
 
             Divider()
 

--- a/Nook/Components/Dialog/DialogView.swift
+++ b/Nook/Components/Dialog/DialogView.swift
@@ -28,8 +28,7 @@ struct DialogView: View {
         .onChange(of: browserManager.dialogManager.isVisible) { _, isVisible in
             if isVisible {
                 // Resign WebView first responder so keyboard events reach the dialog
-                if let window = NSApp.keyWindow,
-                   window.firstResponder is WKWebView {
+                if let window = NSApp.keyWindow {
                     window.makeFirstResponder(nil)
                 }
             }

--- a/Nook/Components/Dialog/DialogView.swift
+++ b/Nook/Components/Dialog/DialogView.swift
@@ -27,8 +27,7 @@ struct DialogView: View {
         .animation(.bouncy(duration: 0.2, extraBounce: -0.1), value: browserManager.dialogManager.isVisible)
         .onChange(of: browserManager.dialogManager.isVisible) { _, isVisible in
             if isVisible {
-                // Resign the WebView as first responder so keyboard events
-                // (Enter, Escape, Tab) go to the dialog buttons instead
+                // Resign WebView first responder so keyboard events reach the dialog
                 if let window = NSApp.keyWindow,
                    window.firstResponder is WKWebView {
                     window.makeFirstResponder(nil)

--- a/Nook/Components/Dialog/DialogView.swift
+++ b/Nook/Components/Dialog/DialogView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import WebKit
 
 struct DialogView: View {
     @EnvironmentObject var browserManager: BrowserManager
@@ -24,6 +25,16 @@ struct DialogView: View {
             }
         }
         .animation(.bouncy(duration: 0.2, extraBounce: -0.1), value: browserManager.dialogManager.isVisible)
+        .onChange(of: browserManager.dialogManager.isVisible) { _, isVisible in
+            if isVisible {
+                // Resign the WebView as first responder so keyboard events
+                // (Enter, Escape, Tab) go to the dialog buttons instead
+                if let window = NSApp.keyWindow,
+                   window.firstResponder is WKWebView {
+                    window.makeFirstResponder(nil)
+                }
+            }
+        }
     }
 
     @ViewBuilder

--- a/Nook/Components/WebsiteView/WebsiteView.swift
+++ b/Nook/Components/WebsiteView/WebsiteView.swift
@@ -220,7 +220,9 @@ struct WebsiteView: View {
                         .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 0)
                         // Critical: Use allowsHitTesting to prevent SwiftUI from intercepting mouse events
                         // This allows right-clicks to pass through to the underlying NSView (WKWebView)
-                        .allowsHitTesting(true)
+                        // Disable hit testing when a dialog is visible so clicks can't reach the WebView
+                        .allowsHitTesting(!browserManager.dialogManager.isVisible)
+                        .contentShape(Rectangle())
                     }
                     // Removed SwiftUI contextMenu - it intercepts ALL right-clicks
                     // WKWebView's willOpenMenu will handle context menus for images

--- a/Nook/Components/WebsiteView/WebsiteView.swift
+++ b/Nook/Components/WebsiteView/WebsiteView.swift
@@ -220,7 +220,6 @@ struct WebsiteView: View {
                         .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 0)
                         // Critical: Use allowsHitTesting to prevent SwiftUI from intercepting mouse events
                         // This allows right-clicks to pass through to the underlying NSView (WKWebView)
-                        // Disable hit testing when a dialog is visible so clicks can't reach the WebView
                         .allowsHitTesting(!browserManager.dialogManager.isVisible)
                         .contentShape(Rectangle())
                     }

--- a/Nook/Managers/DialogManager/DialogManager.swift
+++ b/Nook/Managers/DialogManager/DialogManager.swift
@@ -15,11 +15,14 @@ class DialogManager {
     var isVisible: Bool = false
     var activeDialog: AnyView?
 
+    private nonisolated(unsafe) var tabKeyMonitor: Any?
+
     // MARK: - Presentation
 
     func showDialog<Content: View>(_ dialog: Content) {
         activeDialog = AnyView(dialog)
         isVisible = true
+        installTabKeyMonitor()
     }
 
     func showDialog<Content: View>(@ViewBuilder builder: () -> Content) {
@@ -33,8 +36,30 @@ class DialogManager {
         }
 
         isVisible = false
+        removeTabKeyMonitor()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
             self?.activeDialog = nil
+        }
+    }
+
+    // MARK: - Tab Key Blocking
+
+    private func installTabKeyMonitor() {
+        guard tabKeyMonitor == nil else { return }
+        tabKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Intercept Tab key while a dialog is visible
+            if event.keyCode == 48 { // 48 = Tab
+                NSSound.beep()
+                return nil // swallow the event
+            }
+            return event
+        }
+    }
+
+    private func removeTabKeyMonitor() {
+        if let monitor = tabKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            tabKeyMonitor = nil
         }
     }
 
@@ -54,13 +79,13 @@ class DialogManager {
                         Image("nook-logo-1024")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 26, height: 26)
+                            .frame(width: 50, height: 50)
                             .shadow(
                                 color: AppColors.textPrimary.opacity(0.3),
                                 radius: 0.5,
                                 y: 1
                             )
-                        Text("Are you sure you want to quit Nook?")
+                        Text("Quit Nook?")
                             .font(.system(size: 18, weight: .bold))
                             .foregroundStyle(AppColors.textPrimary)
                         Text("You may lose unsaved work in your tabs.")
@@ -79,13 +104,16 @@ class DialogManager {
                         rightButtons: [
                             DialogButton(
                                 text: "Cancel",
+                                customIcon: AnyView(KeycapLabel("esc")),
                                 variant: .secondary,
+                                keyboardShortcut: .escape,
                                 action: closeDialog
                             ),
                             DialogButton(
                                 text: "Quit",
                                 iconName: "return",
                                 variant: .primary,
+                                keyboardShortcut: .return,
                                 action: onQuit
                             ),
                         ]
@@ -261,62 +289,30 @@ struct DialogFooter: View {
     var body: some View {
         HStack {
             if let leftButton = leftButton {
-                if let iconName = leftButton.iconName {
-                    Button(leftButton.text, action: leftButton.action)
-                        .buttonStyle(
-                            DialogButtonStyle(
-                                variant: leftButton.variant,
-                                icon: leftButton.iconName.map {
-                                    AnyView(Image(systemName: $0))
-                                },
-                                iconPosition: .trailing
-                            )
+                Button(leftButton.text, action: leftButton.action)
+                    .buttonStyle(
+                        DialogButtonStyle(
+                            variant: leftButton.variant,
+                            icon: leftButton.resolvedIcon,
+                            iconPosition: .trailing
                         )
-                        .conditionally(if: OSVersion.supportsGlassEffect) {
-                            View in
-                            View
-                                .tint(
-                                    Color("plainBackgroundColor").opacity(
-                                        colorScheme == .light ? 0.8 : 0.4
-                                    )
+                    )
+                    .conditionally(if: OSVersion.supportsGlassEffect) {
+                        View in
+                        View
+                            .tint(
+                                Color("plainBackgroundColor").opacity(
+                                    colorScheme == .light ? 0.8 : 0.4
                                 )
-                        }
-                        .controlSize(.extraLarge)
-
-                        .disabled(!leftButton.isEnabled)
-                        .modifier(
-                            OptionalKeyboardShortcut(
-                                shortcut: leftButton.keyboardShortcut
                             )
+                    }
+                    .controlSize(.extraLarge)
+                    .disabled(!leftButton.isEnabled)
+                    .modifier(
+                        OptionalKeyboardShortcut(
+                            shortcut: leftButton.keyboardShortcut
                         )
-                } else {
-                    Button(leftButton.text, action: leftButton.action)
-                        .buttonStyle(
-                            DialogButtonStyle(
-                                variant: leftButton.variant,
-                                icon: leftButton.iconName.map {
-                                    AnyView(Image(systemName: $0))
-                                },
-                                iconPosition: .trailing
-                            )
-                        )
-                        .conditionally(if: OSVersion.supportsGlassEffect) {
-                            View in
-                            View
-                                .tint(
-                                    Color("plainBackgroundColor").opacity(
-                                        colorScheme == .light ? 0.8 : 0.4
-                                    )
-                                )
-                        }
-                        .controlSize(.extraLarge)
-                        .disabled(!leftButton.isEnabled)
-                        .modifier(
-                            OptionalKeyboardShortcut(
-                                shortcut: leftButton.keyboardShortcut
-                            )
-                        )
-                }
+                    )
             }
 
             Spacer()
@@ -329,9 +325,7 @@ struct DialogFooter: View {
                         .buttonStyle(
                             DialogButtonStyle(
                                 variant: button.variant,
-                                icon: button.iconName.map {
-                                    AnyView(Image(systemName: $0))
-                                },
+                                icon: button.resolvedIcon,
                                 iconPosition: .trailing
                             )
                         )
@@ -351,15 +345,23 @@ struct DialogFooter: View {
 struct DialogButton {
     let text: String
     let iconName: String?
+    let customIcon: AnyView?
     let variant: DialogButtonStyleVariant
     let action: () -> Void
     let keyboardShortcut: KeyEquivalent?
     let shadowStyle: NookButtonStyle.ShadowStyle
     let isEnabled: Bool
 
+    /// The resolved icon view: customIcon takes priority, then iconName as SF Symbol
+    var resolvedIcon: AnyView? {
+        if let customIcon { return customIcon }
+        return iconName.map { AnyView(Image(systemName: $0)) }
+    }
+
     init(
         text: String,
         iconName: String? = nil,
+        customIcon: AnyView? = nil,
         variant: DialogButtonStyleVariant = .secondary,
         keyboardShortcut: KeyEquivalent? = nil,
         shadowStyle: NookButtonStyle.ShadowStyle = .subtle,
@@ -368,6 +370,7 @@ struct DialogButton {
     ) {
         self.text = text
         self.iconName = iconName
+        self.customIcon = customIcon
         self.variant = variant
         self.action = action
         self.keyboardShortcut = keyboardShortcut
@@ -447,5 +450,23 @@ struct DialogButtonStyle: ButtonStyle {
         .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
         .opacity(configuration.isPressed ? 0.8 : 1.0)
         .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+/// A small rounded badge for displaying keyboard shortcut hints (e.g. "esc", "tab")
+struct KeycapLabel: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .semibold, design: .rounded))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.white.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }

--- a/Nook/Managers/DialogManager/DialogManager.swift
+++ b/Nook/Managers/DialogManager/DialogManager.swift
@@ -15,7 +15,7 @@ class DialogManager {
     var isVisible: Bool = false
     var activeDialog: AnyView?
 
-    private nonisolated(unsafe) var tabKeyMonitor: Any?
+    private var tabKeyMonitor: Any?
 
     // MARK: - Presentation
 

--- a/Nook/Managers/DialogManager/DialogManager.swift
+++ b/Nook/Managers/DialogManager/DialogManager.swift
@@ -47,10 +47,9 @@ class DialogManager {
     private func installTabKeyMonitor() {
         guard tabKeyMonitor == nil else { return }
         tabKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            // Intercept Tab key while a dialog is visible
-            if event.keyCode == 48 { // 48 = Tab
+            if event.keyCode == 48 {
                 NSSound.beep()
-                return nil // swallow the event
+                return nil
             }
             return event
         }


### PR DESCRIPTION
When "warn before quitting" was set to false, CMD+Q broke the app, it didn't quit and the option was greyed out requiring a force quit.

Now, the app quits straight away as expected. Please note that it doesn't close tabs. I'm not sure why tabs are set to close when "warn before quitting" is enabled... is that intended behaviour? Arc does not do that.

Previously, the quitting dialogue didn't prevent input, so you could interact with web pages behind using the tab key. This is confusing. Additionally, although an Enter icon was displayed, it didn't take input.

Now, it takes enter, and ESC for cancel (which is shown visually ala Arc, with keycap). Tab isn't consumed, but things like CMD+1 are. This doesn't seem like good HIG or accessibility - tab should really cycle through dialogue buttons - but how it works in this PR is the same as Arc, which seems to be the aim of this project.

The app icon was increased to match Arc's quit/warn dialogue, as well as the title, but the text underneath remains, in connection to the tab closing confusion.

Claude Opus 4.6 helped me with syntax and structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dialog buttons now show visual keyboard shortcut hints.
  * Added Escape (cancel) and Return (confirm) keyboard shortcuts for dialogs.
  * New "Quit Nook" menu item with Command‑Q to respect quit warning preference.

* **Improvements**
  * Dialogs block Tab key to improve focus handling.
  * Right-click and hit-testing now respect dialog visibility.
  * Quit dialog UI updated with larger logo and shortened prompt text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->